### PR TITLE
Allow NotificationsPid to be both function and pid

### DIFF
--- a/src/deribit_api_websocket.erl
+++ b/src/deribit_api_websocket.erl
@@ -115,7 +115,12 @@ handle_info({gun_ws, _Pid, {text, Text}}, #state{ pids_map = PidsMap, notificati
     {pong} ->
       {noreply, State#state{ last_pong = os:timestamp() }};
     {notifications, _} ->
-      NotificationsPid ! {self(), Result},
+      case NotificationsPid of
+        _ when is_pid(NotificationsPid) ->
+          NotificationsPid ! {self(), Result};
+        _ when is_function(NotificationsPid) ->
+          erlang:apply(NotificationsPid, [Result])
+      end,
       {noreply, State};
     _ ->
       Id = maps:get(<<"id">>, Json, undefined),


### PR DESCRIPTION
Subscribing to websocket with `async: fun/1`, `{notifications, _}` fails as `NotificationsPid` is a function instead of `pid`; it should work for both just like other response backs. 

This PR fixes to support `fun/1` as well as `pid`.