### PR TITLE
Fix flatten list in generate_signature

### DIFF
--- a/src/deribit_api_utils.erl
+++ b/src/deribit_api_utils.erl
@@ -22,7 +22,7 @@ generate_signature(Key, Secret, Uri, Data) ->
 
   ParamsString = deribit_api_utils:to_string(AllData),
   Hash = erlang:binary_to_list(base64:encode(crypto:hash(sha256, ParamsString))),
-  lists:flatten(Key ++ "." ++ Tstamp ++ "." ++ Hash).
+  lists:flatten([Key, ".", Tstamp, ".", Hash]).
 
 to_binary(Data) when is_binary(Data) ->
   Data;


### PR DESCRIPTION
Failing to perform list append in `deribit_api_utils:generate_signature`; have a list instead of appending to create list before flattening.

```
> erl -v

Erlang/OTP 21 [erts-10.1.1] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [hipe]
Eshell V10.1.1
```
